### PR TITLE
(bug) Profile selection was broken

### DIFF
--- a/src/modules/profiles/profile-information/ProfileInformation.tsx
+++ b/src/modules/profiles/profile-information/ProfileInformation.tsx
@@ -7,9 +7,9 @@ import { useParams } from "react-router-dom";
 import { LoadingProfile } from "@/modules/profiles/profile-information/components/ProfileInfo/LoadingProfile";
 
 export function ProfileInformation() {
-  const { name = "", kind = "" } = useParams();
+  const { namespace= "", name = "", kind = "" } = useParams();
 
-  const { data, isLoading, isSuccess } = useProfileInfo(name, kind);
+  const { data, isLoading, isSuccess } = useProfileInfo(namespace, name, kind);
   return (
     <>
       {isLoading && <LoadingProfile />}

--- a/src/modules/profiles/profile-information/components/ProfileRelations/Nodes/DependencyNode.tsx
+++ b/src/modules/profiles/profile-information/components/ProfileRelations/Nodes/DependencyNode.tsx
@@ -5,6 +5,7 @@ import { DividerVerticalIcon } from "@radix-ui/react-icons";
 import { useNavigate } from "react-router-dom";
 
 interface DependencyNodeProps {
+  namespace: string;
   name: string;
   kind: string;
   apiVersion: string;
@@ -13,7 +14,11 @@ export function DependencyNode({ data }: { data: DependencyNodeProps }) {
   const navigate = useNavigate();
 
   function handleNavigation() {
-    navigate(`/sveltos/profile/${data.name}/${data.kind}`);
+    if (data.namespace) {
+      navigate(`/sveltos/profile/${data.namespace}/${data.name}/${data.kind}`);
+    } else {
+      navigate(`/sveltos/profile/${data.name}/${data.kind}`);
+    }
   }
 
   return (

--- a/src/modules/profiles/profile-information/components/ProfileRelations/Nodes/DependentsNode.tsx
+++ b/src/modules/profiles/profile-information/components/ProfileRelations/Nodes/DependentsNode.tsx
@@ -7,7 +7,11 @@ import { useNavigate } from "react-router-dom";
 export function DependentsNode({ data }: { data: Dependency }) {
   const navigate = useNavigate();
   function handleNavigation() {
-    navigate(`/sveltos/profile/${data.name}/${data.kind}`);
+    if (data.namespace) {
+      navigate(`/sveltos/profile/${data.namespace}/${data.name}/${data.kind}`);
+    } else {
+      navigate(`/sveltos/profile/${data.name}/${data.kind}`);
+    }
   }
 
   return (

--- a/src/modules/profiles/profile-information/components/ProfileRelations/ProfileRelations.tsx
+++ b/src/modules/profiles/profile-information/components/ProfileRelations/ProfileRelations.tsx
@@ -35,6 +35,8 @@ export function ProfileRelations({
   profile,
 }: {
   profile: {
+    kind: string,
+    namespace: string,
     name: string;
     apiVersion?: string;
     dependencies: Dependency[];
@@ -71,7 +73,7 @@ export function ProfileRelations({
         type: "custom",
         data: {
           name: profile.name,
-          kind: "Profile",
+          kind: profile.kind,
           apiVersion: profile?.apiVersion,
         },
         position: { x: 0, y: 0 },

--- a/src/modules/profiles/profile-information/hooks/useProfileInfo.ts
+++ b/src/modules/profiles/profile-information/hooks/useProfileInfo.ts
@@ -4,9 +4,10 @@ import { API_ENDPOINTS } from "@/api-client/endpoints";
 import { ProfileInfo } from "@/types/profile.types";
 import { useMemo } from "react";
 
-const fetchProfileInfo = async (name: string, kind: string) => {
+const fetchProfileInfo = async (namespace: string, name: string, kind: string) => {
   const { data } = await client.get(API_ENDPOINTS.PROFILE, {
     params: {
+      namespace,
       name,
       kind,
     },
@@ -15,11 +16,12 @@ const fetchProfileInfo = async (name: string, kind: string) => {
 };
 
 const useProfileInfo = (
+  namespace: string,
   name: string,
   kind: string,
 ): UseQueryResult<ProfileInfo, Error> => {
-  const queryKey = useMemo(() => ["profile-info", name, kind], [name, kind]);
-  return useQuery(queryKey, () => fetchProfileInfo(name, kind), {
+  const queryKey = useMemo(() => ["profile-info", namespace, name, kind], [namespace, name, kind]);
+  return useQuery(queryKey, () => fetchProfileInfo(namespace, name, kind), {
     keepPreviousData: false,
   });
 };

--- a/src/modules/profiles/profiles-list/components/profile/ProfileCard/ProfileCard.tsx
+++ b/src/modules/profiles/profiles-list/components/profile/ProfileCard/ProfileCard.tsx
@@ -6,7 +6,11 @@ import { useNavigate } from "react-router-dom";
 export function ProfileCard({ profile }: { profile: Profile }) {
   const navigate = useNavigate();
   function handleNavigation() {
-    navigate(`/sveltos/profile/${profile.name}/${profile.kind}`);
+    if (profile.namespace) {
+      navigate(`/sveltos/profile/${profile.namespace}/${profile.name}/${profile.kind}`);
+    } else {
+      navigate(`/sveltos/profile/${profile.name}/${profile.kind}`);
+    }
   }
   return (
     <Card

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -43,6 +43,10 @@ export const routes: RouteObject[] = [
         element: <ProfileList />,
       },
       {
+        path: "/sveltos/profile/:namespace/:name/:kind",
+        element: <ProfileInformation />,
+      },
+      {
         path: "/sveltos/profile/:name/:kind",
         element: <ProfileInformation />,
       },

--- a/src/types/addon.types.ts
+++ b/src/types/addon.types.ts
@@ -3,7 +3,7 @@ import { AddonTableTypes } from "@/types/addonTable.types";
 export enum AddonTypes {
   HELM = "Helm Charts",
   RESOURCE = "Resources",
-  PROFILE = "Cluster profiles",
+  PROFILE = "Profiles",
 }
 export type AddonTableData = {
   helmReleases?: AddonData[];

--- a/src/types/profile.types.ts
+++ b/src/types/profile.types.ts
@@ -29,6 +29,7 @@ export type TierData = {
 
 export interface Dependency {
   kind: string;
+  namespace: string;
   name: string;
   apiVersion: string;
 }


### PR DESCRIPTION
When selecting the "Profiles" we see all profiles organized by tier. Here we have both ClusterProfile (which are cluster wide resources) and Profiles (which are namespaced resources).
While selecting a ClusterProfile was correctly loading a page showing the ClusterProfile dependencies and dependents, selecting a Profile was not loading.

The issue is a Profile is identified by namespace and name (while a ClusterProfile is identified just by name).

This PR fixes that (verified it locally).
This PR also makes sure we consistently use "profiles" when generically referencing to both ClusterProfile and Profile.