### PR TITLE
refactor MCP button and  MCP response formatting 

### DIFF
--- a/src/lib/components/ui/inputs/mcp-button.tsx
+++ b/src/lib/components/ui/inputs/mcp-button.tsx
@@ -2,12 +2,13 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
-import { Sparkles } from "lucide-react";
+import { LucideIcon, Sparkles } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/lib/components/ui/feedback/popover";
+import { JSX } from "react";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
@@ -39,7 +40,8 @@ export interface McpButtonProps
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   isLoading?: boolean;
-  popupText?: string;
+  mcpResponse?: string | string[];
+  icon?: LucideIcon | JSX.Element;
 }
 
 const McpButton = React.forwardRef<HTMLButtonElement, McpButtonProps>(
@@ -50,7 +52,8 @@ const McpButton = React.forwardRef<HTMLButtonElement, McpButtonProps>(
       size,
       asChild = false,
       isLoading = false,
-      popupText,
+      icon,
+      mcpResponse,
       ...props
     },
     ref,
@@ -69,27 +72,59 @@ const McpButton = React.forwardRef<HTMLButtonElement, McpButtonProps>(
             disabled={isLoading}
             {...props}
           >
-            {isLoading ? (
-              <Sparkles className="mr-2 h-4 w-4 mx-auto animate-spin text-yellow-500" />
-            ) : (
-              <Sparkles className="mr-2 h-4 w-4 mx-auto text-yellow-500" />
-            )}
-            {props.children}
+            <>
+              {isLoading ? (
+                <Sparkles className="mr-2 h-4 w-4 mx-auto animate-spin text-yellow-500" />
+              ) : (
+                <>
+                  {icon ?? (
+                    <Sparkles className="mr-2 h-4 w-4 mx-auto text-yellow-500" />
+                  )}
+                </>
+              )}
+              {props.children}
+            </>
           </Comp>
         </PopoverTrigger>
-        {popupText && (
-          <PopoverContent className="w-72 text-l rounded-md p-4 flex flex-col space-y-2">
+        {mcpResponse && !isLoading && Array.isArray(mcpResponse) && (
+          <PopoverContent className="w-96 text-l rounded-md p-4 flex flex-col space-y-2">
+            {mcpResponse.map((text, index) => {
+              const errorMatch = text.match(/(Error:)(.*)/); // Match "Error:" and the text after it
+              return (
+                <div key={index} className="flex flex-col space-y-1">
+                  <h4 className="text-lg font-semibold">
+                    <span className="relative pl-6">
+                      <Sparkles className="absolute left-0 top-0 h-5 w-5 text-yellow-500" />
+                      {text.split(".")[0] + "."}
+                    </span>
+                  </h4>
+                  <span className="text-left">
+                    {errorMatch ? (
+                      <>
+                        {text.split("Error:")[0]}
+                        <span className="text-red-500 my-2 font-bold text-md">
+                          Error:{errorMatch[2]}
+                        </span>
+
+                        {/* Separator */}
+                      </>
+                    ) : (
+                      text.split(".").slice(1).join(".").trim()
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </PopoverContent>
+        )}
+        {mcpResponse && !isLoading && !Array.isArray(mcpResponse) && (
+          <PopoverContent className="w-72 text-l rounded-md p-4">
             <h4 className="text-lg font-semibold">
               <span className="relative pl-6">
                 <Sparkles className="absolute left-0 top-0 h-5 w-5 text-yellow-500" />
-                {popupText.split(".")[0] + "."}
+                {mcpResponse}
               </span>
             </h4>
-            <div className="flex space-x-2">
-              <span className="text-left">
-                {popupText.split(".").slice(1).join(".").trim()}
-              </span>
-            </div>
           </PopoverContent>
         )}
       </Popover>

--- a/src/lib/components/ui/inputs/mcp-button.tsx
+++ b/src/lib/components/ui/inputs/mcp-button.tsx
@@ -41,7 +41,7 @@ export interface McpButtonProps
   asChild?: boolean;
   isLoading?: boolean;
   mcpResponse?: string | string[];
-  icon?: LucideIcon | JSX.Element;
+  icon?: React.ReactNode;
 }
 
 const McpButton = React.forwardRef<HTMLButtonElement, McpButtonProps>(

--- a/src/modules/clusters/cluster-information/components/addonsTable/rows/ProfileRow.tsx
+++ b/src/modules/clusters/cluster-information/components/addonsTable/rows/ProfileRow.tsx
@@ -65,7 +65,11 @@ export const ProfileRow = ({ row, columns, onOpenRepo }: ProfileRowProps) => {
                   <McpButton
                     onClick={triggerMcp}
                     isLoading={debugProfileClusterQuery?.isFetching}
-                    popupText={debugProfileClusterQuery?.data}
+                    mcpResponse={
+                      debugProfileClusterQuery?.data
+                        ? debugProfileClusterQuery.data
+                        : "No debug data available."
+                    }
                     variant={"highlight"}
                   >
                     Debug

--- a/src/modules/clusters/cluster-information/components/clusterHeading.tsx
+++ b/src/modules/clusters/cluster-information/components/clusterHeading.tsx
@@ -5,6 +5,8 @@ import { useNavigate } from "react-router-dom";
 import { Icons } from "@/lib/components/icons";
 import { RefreshButton } from "@/modules/common/components/actions/RefreshButton";
 import { McpButton } from "@/lib/components/ui/inputs/mcp-button";
+import { DebugClusterResponse } from "@/hooks/useMcp";
+import { useQueryClient } from "react-query";
 
 type ClusterHeadingProps = {
   name: string;
@@ -13,7 +15,11 @@ type ClusterHeadingProps = {
   namespace?: string;
   hideDetails?: boolean;
   failureMsg?: string | null;
-  mcpDebugQuery?: { refetch: () => void; isFetching: boolean; data?: string };
+  mcpDebugQuery?: {
+    refetch: () => void;
+    isFetching: boolean;
+    data?: DebugClusterResponse;
+  };
 };
 
 export const ClusterHeading = ({
@@ -26,14 +32,9 @@ export const ClusterHeading = ({
   mcpDebugQuery,
 }: ClusterHeadingProps) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   function triggerMcpDebugQuery() {
-    console.log("Triggering MCP Debug Query...");
-    if (mcpDebugQuery) {
-      console.log("Refetching...");
-      mcpDebugQuery.refetch();
-    } else {
-      console.error("mcpDebugQuery is undefined");
-    }
+    mcpDebugQuery?.refetch();
   }
   return (
     <>
@@ -87,7 +88,11 @@ export const ClusterHeading = ({
           <McpButton
             onClick={triggerMcpDebugQuery}
             isLoading={mcpDebugQuery?.isFetching}
-            popupText={mcpDebugQuery?.data || ""}
+            mcpResponse={
+              mcpDebugQuery?.data?.formattedData?.length
+                ? mcpDebugQuery.data.formattedData
+                : "Relax, nothing to debug here!"
+            }
           >
             Debug
           </McpButton>

--- a/src/modules/common/components/actions/VerifyInstallation.tsx
+++ b/src/modules/common/components/actions/VerifyInstallation.tsx
@@ -1,5 +1,8 @@
 import { useMcp } from "@/hooks/useMcp";
 import { McpButton } from "@/lib/components/ui/inputs/mcp-button";
+import { CheckIcon } from "@radix-ui/react-icons";
+import { Sparkles } from "lucide-react";
+import * as React from "react";
 
 export function VerifyInstallation() {
   const { installationQuery } = useMcp("", "", "", "", "");
@@ -11,10 +14,19 @@ export function VerifyInstallation() {
     <McpButton
       variant="default"
       onClick={triggerQuery}
+      icon={
+        installationQuery?.data?.is_correctly_installed ? (
+          <CheckIcon className="mr-2 h-4 w-4 animate-pulse mx-auto text-green-600" />
+        ) : (
+          <Sparkles className="mr-2 h-4 w-4 mx-auto text-yellow-500" />
+        )
+      }
       isLoading={installationQuery?.isFetching}
-      popupText={installationQuery?.data || ""}
+      mcpResponse={installationQuery?.data?.details || ""}
     >
-      Verify Installation
+      {installationQuery?.data?.is_correctly_installed
+        ? "Correctly Installed"
+        : "Verify Installation"}
     </McpButton>
   );
 }

--- a/src/types/profile.types.ts
+++ b/src/types/profile.types.ts
@@ -71,3 +71,8 @@ export interface ProfileInfo {
     }[];
   };
 }
+export interface FailedProfile {
+  profileName: string;
+  isSuccessful: boolean;
+  causes: string[];
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,3 +7,4 @@
   },
   "include": ["vite.config.ts"]
 }
+


### PR DESCRIPTION
This pull request refactors the MCP Button


* Added the `FailedProfile` type to `profile.types.ts` to consistently format MCP debug responses. 

* Updated the `McpButton` component to accept and render complex MCP responses (`mcpResponse`), support custom icons, and display error messages with improved formatting. 
* Modified usages of `McpButton` in `ProfileRow`, `ClusterHeading`, and `VerifyInstallation` to the new response 
