### PR TITLE
cluster UI polish — spacing, label overflow, tier label size, filter order

### DIFF
--- a/src/lib/components/ui/data-display/badge.tsx
+++ b/src/lib/components/ui/data-display/badge.tsx
@@ -36,7 +36,7 @@ function Badge({ className, variant, ...props }: BadgeProps) {
 
   return (
     <div
-      className={` ${cn(badgeVariants({ variant }), className)} ${isLabelVariant ? "max-w-[6rem] md:max-w-[10rem] lg:max-w-[30rem]" : ""}`}
+      className={` ${cn(badgeVariants({ variant }), className)} ${isLabelVariant ? "max-w-[6rem] md:max-w-[10rem] lg:max-w-[12rem]" : ""}`}
       {...props}
     />
   );

--- a/src/modules/clusters/clusters-list/components/ClusterCard.tsx
+++ b/src/modules/clusters/clusters-list/components/ClusterCard.tsx
@@ -90,16 +90,16 @@ export const ClusterCard = ({
             <TooltipTrigger>
               {labelEntries.length > 0 && (
                 <div className="flex items-center space-x-2">
-                  <div style={{ display: "flex", flexDirection: "column" }}>
+                  <div className="flex flex-col overflow-hidden max-w-[8rem] md:max-w-[10rem] lg:max-w-[12rem]">
                     {displayEntries.map(([key, value]) => (
                       <Badge
                         key={`${key}: ${value}`}
                         className={
-                          "my-0.5 dark:bg-slate-800 bg-slate-300 hover:animate-in border-2 rounded"
+                          "my-0.5 dark:bg-slate-800 bg-slate-300 hover:animate-in border-2 rounded w-full overflow-hidden"
                         }
                         variant="label"
                       >
-                        <p className="truncate">{`${key}: ${value}`}</p>
+                        <p className="truncate w-full">{`${key}: ${value}`}</p>
                       </Badge>
                     ))}
                   </div>

--- a/src/modules/clusters/clusters-list/components/searchFieldTags.tsx
+++ b/src/modules/clusters/clusters-list/components/searchFieldTags.tsx
@@ -77,7 +77,7 @@ export const SearchFieldTags = ({
 
   return (
     <>
-      <div className="hidden sm:flex h-5 items-center justify-end space-x-4 text-sm">
+      <div className="hidden sm:flex mt-6 items-end justify-end space-x-4 text-sm">
         {searchFieldsData.map((field, index) => (
           <div key={index} className="search">
             <Label

--- a/src/modules/clusters/clusters-list/config/clusterSearchfields.consts.ts
+++ b/src/modules/clusters/clusters-list/config/clusterSearchfields.consts.ts
@@ -3,16 +3,16 @@ import { SearchField } from "@/modules/clusters/clusters-list/components/searchF
 
 export const clusterSearchfields: SearchField[] = [
   {
-    icon: ALargeSmall,
-    label: "common.name",
-    placeholder: "common.filter_name",
-    termKey: "name",
-  },
-  {
     icon: Blocks,
     label: "common.namespace",
     placeholder: "common.filter_namespace",
     termKey: "namespace",
+  },
+  {
+    icon: ALargeSmall,
+    label: "common.name",
+    placeholder: "common.filter_name",
+    termKey: "name",
   },
   {
     icon: Tags,

--- a/src/modules/profiles/profiles-list/components/tier/TierCard.tsx
+++ b/src/modules/profiles/profiles-list/components/tier/TierCard.tsx
@@ -16,11 +16,11 @@ export function TierCard({ tier, dryRun }: { tier: Tier; dryRun?: boolean }) {
       <Card className="max-w-sm">
         <CardHeader className="border-b border-border mb-2 flex-row gap-3 py-3 px-4">
           <h1 className="flex items-center">
-            <span className="text-muted-foreground mr-2 text-xs font-bold uppercase tracking-wider">
+            <span className="text-muted-foreground mr-2 text-sm font-bold uppercase tracking-wider">
               Tier
             </span>
             <span>
-              <Badge className="bg-zinc-100 text-zinc-900 border border-zinc-200 shadow-none font-bold px-2 py-0">
+              <Badge className="bg-zinc-100 text-zinc-900 border border-zinc-200 shadow-none font-bold text-sm px-2 py-0">
                 {tier?.id}
               </Badge>
             </span>


### PR DESCRIPTION
- Filter row spacing: added top margin to the search filter row so it no longer visually runs into the SveltosCluster/ClusterAPI tab strip
- Label overflow: constrained the labels column in ClusterCard preventing long labels from overflowing card boundaries and overlapping adjacent cards
- Tier label size: increased the "Tier" heading and ID badge in TierCard to match the visual weight of the Dry Run nav  tab
- Search field order: reordered cluster search fields to namespace → name → labels