### PR TITLE
add runtime OIDC configuration via config.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,15 @@ RUN npm run build
 # 2: Prepare the runtime environment
 FROM alpine AS runner
 
-# Install Node.js, npm, Nginx, envsubst
-RUN apk add --no-cache nodejs npm nginx gettext \
+# Install Nginx and envsubst (gettext)
+RUN apk add --no-cache nginx gettext \
   && mkdir -p /etc/nginx/templates \
   && mkdir -p /etc/nginx/conf.d
 
 WORKDIR /app
 
-# Copy build output and deps
+# Copy build output
 COPY --from=builder /build/dist /app/dist
-COPY --from=builder /build/node_modules /app/node_modules
-COPY --from=builder /build/package.json /app/package.json
 
 # Copy custom nginx.conf to replace default
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ COPY nginx.conf /etc/nginx/nginx.conf
 # Copy Nginx template and entrypoint script
 COPY nginx.template.conf /etc/nginx/templates/nginx.template.conf
 COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
+COPY scripts/config.template.js /docker-entrypoint.d/config.template.js
 RUN chmod +x /docker-entrypoint.sh
 
 # ENV vars

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <body class="min-h-screen">
     <noscript> To use SveltosUI, please enable JavaScript. </noscript>
     <div id="root" class="relative flex min-h-screen flex-col"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,6 @@
+// Overridden at runtime by the Docker entrypoint when deployed.
+window.__CONFIG__ = {
+  oidcIssuer: "",
+  oidcClientId: "",
+  oidcRedirectUri: "",
+};

--- a/scripts/config.template.js
+++ b/scripts/config.template.js
@@ -1,0 +1,5 @@
+window.__CONFIG__ = {
+  oidcIssuer: "${OIDC_ISSUER}",
+  oidcClientId: "${OIDC_CLIENT_ID}",
+  oidcRedirectUri: "${OIDC_REDIRECT_URI}",
+};

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,6 +6,9 @@ echo "🔧 Starting Docker Entrypoint..."
 echo "📦 ENV values:"
 echo "  - VITE_BACKEND_NAME: $VITE_BACKEND_NAME"
 echo "  - VITE_BACKEND_PORT: $VITE_BACKEND_PORT"
+echo "  - OIDC_ISSUER: $OIDC_ISSUER"
+echo "  - OIDC_CLIENT_ID: $OIDC_CLIENT_ID"
+echo "  - OIDC_REDIRECT_URI: $OIDC_REDIRECT_URI"
 
 # Confirm template file exists
 TEMPLATE_PATH="/etc/nginx/templates/nginx.template.conf"
@@ -18,7 +21,13 @@ fi
 
 echo "📄 Found template at $TEMPLATE_PATH"
 
-# Generate config from template
+# Generate runtime config.js from template
+echo "🔁 Generating runtime config.js..."
+envsubst '$OIDC_ISSUER $OIDC_CLIENT_ID $OIDC_REDIRECT_URI' \
+  < /docker-entrypoint.d/config.template.js \
+  > /app/dist/config.js
+
+# Generate nginx config from template
 echo "🔁 Substituting env vars into Nginx config..."
 envsubst '$VITE_BACKEND_PORT $VITE_BACKEND_NAME' < "$TEMPLATE_PATH" > "$CONF_PATH"
 

--- a/src/modules/authentication/oidc.ts
+++ b/src/modules/authentication/oidc.ts
@@ -1,9 +1,15 @@
 import { UserManager, WebStorageStateStore } from "oidc-client-ts";
 
-const authority = import.meta.env.VITE_OIDC_ISSUER as string | undefined;
-const clientId = import.meta.env.VITE_OIDC_CLIENT_ID as string | undefined;
+// Prefer runtime config (injected by Docker entrypoint); fall back to build-time env vars for local dev.
+const authority =
+  window.__CONFIG__?.oidcIssuer ||
+  (import.meta.env.VITE_OIDC_ISSUER as string | undefined);
+const clientId =
+  window.__CONFIG__?.oidcClientId ||
+  (import.meta.env.VITE_OIDC_CLIENT_ID as string | undefined);
 const redirectUri =
-  (import.meta.env.VITE_OIDC_REDIRECT_URI as string | undefined) ??
+  window.__CONFIG__?.oidcRedirectUri ||
+  (import.meta.env.VITE_OIDC_REDIRECT_URI as string | undefined) ||
   `${window.location.origin}/oidc-callback`;
 
 // Derive the route path from the redirect URI

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -1,0 +1,13 @@
+interface AppConfig {
+  oidcIssuer: string;
+  oidcClientId: string;
+  oidcRedirectUri: string;
+}
+
+declare global {
+  interface Window {
+    __CONFIG__: AppConfig;
+  }
+}
+
+export {};


### PR DESCRIPTION
OIDC env vars (OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_REDIRECT_URI) are now injected at container startup via envsubst into /app/dist/config.js, which the app reads from `window.__CONFIG__` at runtime. This replaces the previous approach of relying on Vite build-time env vars (VITE_OIDC_*), which were baked into the JS bundle and unreachable from Helm values set on the Kubernetes deployment.

remove unnecessary nodejs, npm from runner Docker image